### PR TITLE
Revise time and commit schedule

### DIFF
--- a/.github/workflows/gist_cron.yml
+++ b/.github/workflows/gist_cron.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - test-*
   schedule:
-    - cron: '14 2 */3 * *'
+    - cron: '15 1-21/4 * * *'
   workflow_dispatch:
     inputs:
       do_commit:
@@ -26,7 +26,7 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: '3.9'
 
     - name: Update pip
       run: python -m pip install -U pip

--- a/do_commit
+++ b/do_commit
@@ -14,8 +14,12 @@ do_commit () {
 
 if [[ $TRIGGER = "schedule" ]]
 then
-  do_commit
-  exit 0
+  python -m time_check
+  if [[ $? -gt 0 ]]
+  then
+    do_commit
+    exit 0
+  fi
 fi
 
 if [[ $TRIGGER = "workflow_dispatch" && $COMMIT_OPTION = "Y" ]]

--- a/time_check.py
+++ b/time_check.py
@@ -1,0 +1,41 @@
+r"""*Module to provide commit-or-not indicator.*
+
+**Author**
+    Brian Skinn (bskinn@alum.mit.edu)
+
+**File Created**
+    23 Feb 2022
+
+**Copyright**
+    \(c) Brian Skinn 2021-2022
+
+**Source Repository**
+    http://www.github.com/bskinn/intersphinx-gist
+
+**Documentation**
+    N/A
+
+**License**
+    The MIT License; see |license_txt|_ for full license terms
+
+**Members**
+
+"""
+
+import datetime
+import sys
+
+
+def main() -> int:
+    """Return 1 for 'commit' or 0 for 'no commit'.
+
+    Only commit between midnight and 2am on a Sunday.
+
+    """
+    now = datetime.datetime.utcnow()
+
+    return 1 if (now.weekday == 6 and 0 <= now.hour <= 2) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Now should run every four hours, but only commit the check
log back to the repo once per week.

This will warn me quickly if something breaks, while not
flooding the repo with update commits...but also while still
keeping the commit flow coming so that the cron workflow schedule
will stay active.